### PR TITLE
fix(nsg_snackbar): guard against null Get.context / overlayContext (Refs NSG-SOFT/futbolista-tasks#205)

### DIFF
--- a/lib/widgets/nsg_snackbar.dart
+++ b/lib/widgets/nsg_snackbar.dart
@@ -1,4 +1,5 @@
 import 'package:another_flushbar/flushbar.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../nsg_control_options.dart';
@@ -26,41 +27,60 @@ void nsgSnackbar({
   Color? color,
   Color? backColor,
 }) {
-  Flushbar(
-    onTap: onTap,
-    boxShadows: [BoxShadow(color: Colors.black.withAlpha(128), spreadRadius: 5, blurRadius: 15, offset: const Offset(0, -5))],
-    backgroundColor: backColor ?? ControlOptions.instance.colorMain,
-    messageColor: ControlOptions.instance.colorMainText,
-    titleText: title == null
-        ? null
-        : Text(
-            title,
-            textAlign: textAlign ?? TextAlign.center,
-            style: TextStyle(
-              fontSize: fontSize ?? ControlOptions.instance.sizeL,
-              color: color ?? ControlOptions.instance.colorMainText,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-    messageText: Text(
-      text,
-      textAlign: textAlign ?? TextAlign.center,
-      style: TextStyle(color: color ?? ControlOptions.instance.colorMainText, fontSize: fontSize ?? ControlOptions.instance.sizeL),
-    ),
-    duration: duration ?? const Duration(seconds: 3),
-    maxWidth: 640,
-    icon: type == null ? null : Icon(type.icon, color: ControlOptions.instance.colorMainText),
-  ).show(context ?? Get.context!);
+  // Issue NSG-SOFT/futbolista-tasks#205 (related to #26):
+  // `Get.context!` падает с null-check на холодном старте — когда snackbar
+  // стреляет из background-Future (deep-link callback, ошибка авторизации) до
+  // того, как Navigator/MaterialApp смонтировался. Используем `overlayContext`
+  // (живёт дольше, чем `Get.context`), откладываем показ на следующий кадр
+  // если overlay ещё не готов, и оборачиваем `.show()` в try/catch на случай
+  // если страница уже dispose'нута между check'ом и show'ом.
+  Flushbar<dynamic> buildBar() => Flushbar(
+        onTap: onTap,
+        boxShadows: [BoxShadow(color: Colors.black.withAlpha(128), spreadRadius: 5, blurRadius: 15, offset: const Offset(0, -5))],
+        backgroundColor: backColor ?? ControlOptions.instance.colorMain,
+        messageColor: ControlOptions.instance.colorMainText,
+        titleText: title == null
+            ? null
+            : Text(
+                title,
+                textAlign: textAlign ?? TextAlign.center,
+                style: TextStyle(
+                  fontSize: fontSize ?? ControlOptions.instance.sizeL,
+                  color: color ?? ControlOptions.instance.colorMainText,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+        messageText: Text(
+          text,
+          textAlign: textAlign ?? TextAlign.center,
+          style: TextStyle(color: color ?? ControlOptions.instance.colorMainText, fontSize: fontSize ?? ControlOptions.instance.sizeL),
+        ),
+        duration: duration ?? const Duration(seconds: 3),
+        maxWidth: 640,
+        icon: type == null ? null : Icon(type.icon, color: ControlOptions.instance.colorMainText),
+      );
 
-  /* Get.snackbar(title ?? (type == null ? '' : type.title), text,
-      icon: type == null ? null : Icon(type.icon, color: ControlOptions.instance.colorMainText),
-      duration: duration ?? const Duration(seconds: 3),
-      maxWidth: 300,
-      snackPosition: SnackPosition.BOTTOM,
-      barBlur: 0,
-      overlayBlur: 0,
-      borderRadius: 4,
-      snackStyle: SnackStyle.GROUNDED,
-      colorText: ControlOptions.instance.colorMainText,
-      backgroundColor: ControlOptions.instance.colorMainDark);*/
+  void show() {
+    final effectiveContext = context ?? Get.overlayContext ?? Get.context;
+    if (effectiveContext == null) {
+      if (kDebugMode) {
+        debugPrint('[nsgSnackbar] overlay/context still null after frame — dropping snackbar: ${title ?? ''} / $text');
+      }
+      return;
+    }
+    try {
+      buildBar().show(effectiveContext);
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[nsgSnackbar] swallowed: $e');
+      }
+    }
+  }
+
+  if (context != null || Get.overlayContext != null || Get.context != null) {
+    show();
+    return;
+  }
+  // overlay ещё не смонтирован — ждём следующего кадра и пробуем один раз
+  WidgetsBinding.instance.addPostFrameCallback((_) => show());
 }


### PR DESCRIPTION
Fixes a null-check crash in `nsgSnackbar` for cold-start scenarios where the snackbar is fired from a background Future (deep-link callback, auth error) before Navigator/MaterialApp is mounted.

## Root cause

`Flushbar(...).show(context ?? Get.context!)` falls when `Get.context` is null. Same class as Issue [#26](https://github.com/NSG-SOFT/futbolista-tasks/issues/26) in `footballers_diary_app`, but a different entry point — that one wrapped `Get.snackbar(...)` calls in `lib/helpers/safe_snackbar.dart`. Fixing here means every consumer of nsg_controls benefits without having to wrap each call site.

## Fix

- Prefer `Get.overlayContext` (lives longer than `Get.context`) over `Get.context` when no explicit `context` parameter is passed.
- If both are null at call time, defer to next frame via `WidgetsBinding.addPostFrameCallback`. After one retry, if context is still null — drop the snackbar with a `kDebugMode` debug log (losing one snackbar is better than crashing).
- Wrap `.show()` in `try/catch` — if the page disposes between the null check and show, swallow with a debug log.

## API surface

Unchanged. Same parameters, same callers — no migration needed for consumers (`footballers_diary_app`, Tech2Server-frontend, scif_wms_*, etc.).

## Test plan

- [x] `flutter analyze --no-pub lib/widgets/nsg_snackbar.dart` → No issues.
- [ ] Smoke: bump pubspec.yaml ref in `footballers_diary_app` (separate PR), deploy `/test/205/`, verify normal snackbars still appear.
- [ ] No new GlitchTip events with this signature on next release after merge.

## Related

- Original GlitchTip cluster: GT-174 / GT-175 / GT-176 (FUTBOLISTA-APP-5E/5F/5G)
- Related fix in fb-diary-app: NSG-SOFT/futbolista-tasks#26 (PR zenalex/footballers_diary_app#72) — same root cause class, different call sites.

Refs NSG-SOFT/futbolista-tasks#205.