### PR TITLE
NsgErrorWidget: guard Get.dialog against null overlay/context (Refs NSG-SOFT/futbolista-tasks#659)

### DIFF
--- a/lib/widgets/nsg_error_widget.dart
+++ b/lib/widgets/nsg_error_widget.dart
@@ -91,6 +91,16 @@ class NsgErrorWidget {
   }
 
   static Future _showError(String errorMessage, String title) async {
+    // #659 (GT-697): Get.dialog падал null-check, когда нет активного overlay/
+    // navigator (ошибка прилетела во время перехода или до готовности UI) —
+    // падал сам показ ошибки. Guard: нет контекста для диалога → логируем и
+    // выходим, без краша.
+    if (Get.overlayContext == null && Get.context == null) {
+      debugPrint(
+        'NsgErrorWidget._showError: нет overlay/context — диалог ошибки пропущен ($title): $errorMessage',
+      );
+      return;
+    }
     await Get.dialog(
       Builder(
         builder: (dialogContext) {


### PR DESCRIPTION
## Root cause

`NsgErrorWidget._showError()` (`lib/widgets/nsg_error_widget.dart`) вызывал `Get.dialog` без проверки контекста. Когда ошибка прилетает при отсутствии активного overlay/navigator (во время перехода / до готовности UI), `Get.dialog` внутри падает null-check (`extension_navigation.dart:84`) — крашится сам показ ошибки. GT-697 / NSG-SOFT/futbolista-tasks#659.

## Fix
Guard перед `Get.dialog`: если `Get.overlayContext == null && Get.context == null` — логируем (`debugPrint`) и выходим, без краша.

## API surface impact
**Нет.** Сигнатура не изменена.

## Cross-package compat
Локально в показе диалога ошибки. Потребители `nsg_controls` (futbolista, Tech2-frontend, scif_wms) по API не затронуты; при наличии контекста поведение прежнее, без контекста — раньше краш, теперь тихий пропуск показа (ошибка уже в логах/GlitchTip).

## Test plan
- Спровоцировать ошибку (`NsgApiException`) во время перехода / до готовности UI → не краш (раньше null-check на показе ошибки).

Refs NSG-SOFT/futbolista-tasks#659.
