### PR TITLE
fix(nsg_input): зажимать offset выделения в Double-поле (invalid text selection)

### DIFF
--- a/lib/formfields/nsg_input.dart
+++ b/lib/formfields/nsg_input.dart
@@ -437,6 +437,14 @@ class _NsgInputState extends State<NsgInput> {
         String text = textController.text;
         text = text.replaceAll(',', '.');
         text = text.replaceAll(RegExp('[^0-9.-]'), '');
+        // После фильтрации текст может стать короче исходного, тогда сохранённый
+        // offset выходит за границы и TextSelection бросает
+        // "FlutterError: invalid text selection" (GT-451 / fb-diary#486).
+        // Зажимаем offset в границы — как уже сделано в ветке car-plate ниже.
+        if (start > text.length) {
+          start = text.length;
+          end = start;
+        }
         widget.dataItem.setFieldValue(widget.fieldName, text);
         _ignoreChange = true;
         try {


### PR DESCRIPTION
## Что
`NsgInput` для `NsgDataDoubleField` падал с `FlutterError: invalid text selection: TextSelection.collapsed(offset: N…)` (GT-451).

## Почему
В listener'е после фильтрации ввода (`replaceAll(',', '.')` + удаление `[^0-9.-]`) текст становится короче, а сохранённый `start/end` указывает за его конец → `TextSelection(baseOffset: start, …)` бросает исключение.

## Фикс
Зажимаем `start/end` в `text.length` перед установкой выделения — ровно как уже сделано в ветке `car-plate` этого же listener. 3 строки, API пакета не меняется.

Потребитель: `zenalex/footballers_diary_app` (issue NSG-SOFT/futbolista-tasks#486), bump-PR с `dependency_overrides` на эту ветку — отдельно.
